### PR TITLE
Font Awesome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.cache

--- a/.sassrc
+++ b/.sassrc
@@ -1,0 +1,5 @@
+{
+  "includePaths": [
+    "node_modules/font-awesome/scss"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
     "sass": "^1.22.9"
   },
   "scripts": {
-  	"build": "parcel build test/admin.scss --no-content-hash",
-  	"build2": "parcel build test/admin.scss --no-source-maps --no-content-hash"
+    "build": "parcel build test/admin.scss --no-content-hash",
+    "build2": "parcel build test/admin.scss --no-source-maps --no-content-hash"
+  },
+  "dependencies": {
+    "font-awesome": "^4.7.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2246,6 +2246,11 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+font-awesome@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/font-awesome/-/font-awesome-4.7.0.tgz#8fa8cf0411a1a31afd07b06d2902bb9fc815a133"
+  integrity sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM=
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"


### PR DESCRIPTION
Turned out to be font-awesome.

Font Awesome has its own file named _mixins.scss. Having font-awesome in my includePath will confuse sass in terms of what _mixins.scss file to include.

When using `--no-source-maps` it seems to include the one in font-awesome. When you leave the flag out, it includes the one in the actual project. Odd behaviour, but I'm not sure if this is an actual Parcel issue anymore.

Also, even if I have font-awesome installed and `--no-source-maps` enabled, the sass compiler doesn't fail if all your files are in root.

Thanks for digging this out. I'll just rename my mixins file in the meantime to get rid of the issue.